### PR TITLE
VRRenderTarget.h missing UMaterial header. Fails to compile on Android

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/Misc/VRRenderTargetManager.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/Misc/VRRenderTargetManager.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "Serialization/ArchiveSaveCompressedProxy.h"
 #include "Serialization/ArchiveLoadCompressedProxy.h"
 
@@ -12,6 +14,7 @@
 #include "TimerManager.h"
 #include "GameFramework/PlayerController.h"
 #include "Engine/Canvas.h"
+#include "Materials/Material.h"
 //#include "ImageWrapper/Public/IImageWrapper.h"
 //#include "ImageWrapper/Public/IImageWrapperModule.h"
 


### PR DESCRIPTION
Re-added materials include file and added #pragma once guard.