### PR TITLE
Fixed super::super chaining in VRBaseCharacter

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacter.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacter.cpp
@@ -136,7 +136,7 @@ void AVRBaseCharacter::PostInitializeComponents()
 {
 	QUICK_SCOPE_CYCLE_COUNTER(STAT_Character_PostInitComponents);
 
-	Super::Super::PostInitializeComponents();
+	Super::PostInitializeComponents();
 
 	if (!IsPendingKill())
 	{


### PR DESCRIPTION
Fixed super::super chaining in VRBaseCharacter which could skip parent class PostInitializeComponents.