### PR TITLE
Add potential fallback when not vrchar

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRStereoWidgetComponent.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRStereoWidgetComponent.cpp
@@ -551,6 +551,16 @@ void UVRStereoWidgetComponent::TickComponent(float DeltaTime, enum ELevelTick Ti
 							bHandledTransform = true;
 						}
 					}
+					else if (UCameraComponent* Camera = mpawn->FindComponentByClass<UCameraComponent>())
+					{
+						// Look for generic camera comp and use its attach parent
+						if (USceneComponent* CameraParent = Camera->GetAttachParent())
+						{
+							Transform = GetComponentTransform().GetRelativeTransform(CameraParent->GetComponentTransform());
+							Transform = FTransform(FRotator(0.f, -180.f, 0.f)) * Transform;
+							bHandledTransform = true;							
+						}
+					}
 
 					if(!bHandledTransform) // Just use the pawn as we don't know the heirarchy
 					{


### PR DESCRIPTION
We have a non vrcharacter base spectator pawn. It has a component heirarchy similar to the epic doc [example](https://docs.unrealengine.com/Images/SharingAndReleasing/XRDevelopment/VR/DevelopVR/MotionController/Finshed_MC_Setup.webp)

To snap/smooth turn we set relative rotation on the VRRoot component which then makes stereo widgets render incorrectly in headset.

Added this fix in our project to work around it which seems like it might be a reasonable default if not a vrcharacter