### PR TITLE
Fix incorrect ordering of rotation composition

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacter.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacter.cpp
@@ -820,7 +820,7 @@ FVector AVRBaseCharacter::SetActorLocationAndRotationVR(FVector NewLoc, FRotator
 	if (bAccountForHMDRotation)
 	{
 		NewRotation = UVRExpansionFunctionLibrary::GetHMDPureYaw_I(VRReplicatedCamera->GetRelativeRotation());//bUseControllerRotationYaw && OwningController ? OwningController->GetControlRotation() : GetActorRotation();
-		NewRotation = (NewRotation.Quaternion().Inverse() * NewRot.Quaternion()).Rotator();
+		NewRotation = (NewRot.Quaternion() * NewRotation.Quaternion().Inverse()).Rotator();
 	}
 	else
 		NewRotation = NewRot;


### PR DESCRIPTION
When trying to do custom movement, where the picth/roll of new rotations werent always zero, noticed that I was getting incorrect results. Pretty sure this fixes - it's now the same as in SetActorRotationVR