### PR TITLE
Fix bMatchRotation for mirroring & bAlwaysInRange

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRExpansionFunctionLibrary.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRExpansionFunctionLibrary.cpp
@@ -242,116 +242,13 @@ void UVRExpansionFunctionLibrary::GetGripSlotInRangeByTypeName(FName SlotType, A
 	if (!Actor)
 		return;
 
-	MaxRange = FMath::Square(MaxRange);
-
 	if (USceneComponent *rootComp = Actor->GetRootComponent())
 	{
-		FVector RelativeWorldLocation = rootComp->GetComponentTransform().InverseTransformPosition(WorldLocation);
-		float ClosestSlotDistance = -0.1f;
-
-		TArray<FName> SocketNames = rootComp->GetAllSocketNames();
-
-		FString GripIdentifier = SlotType.ToString();
-
-		int foundIndex = 0;
-
-		for (int i = 0; i < SocketNames.Num(); ++i)
-		{
-			if (SocketNames[i].ToString().Contains(GripIdentifier, ESearchCase::IgnoreCase, ESearchDir::FromStart))
-			{
-			
-				float vecLen = FVector::DistSquared(RelativeWorldLocation, rootComp->GetSocketTransform(SocketNames[i], ERelativeTransformSpace::RTS_Component).GetLocation());
-
-				if (MaxRange >= vecLen && (ClosestSlotDistance < 0.0f || vecLen < ClosestSlotDistance))
-				{
-					ClosestSlotDistance = vecLen;
-					bHadSlotInRange = true;
-					foundIndex = i;
-				}
-			}
-		}
-
-		TArray<USceneComponent*> AttachChildren = rootComp->GetAttachChildren();
-
-		TArray<UHandSocketComponent*> RotationallyMatchingHandSockets;
-		for (USceneComponent * AttachChild : AttachChildren)
-		{
-			if (AttachChild && AttachChild->IsA<UHandSocketComponent>())
-			{
-				if (UHandSocketComponent* SocketComp = Cast<UHandSocketComponent>(AttachChild))
-				{
-					if (!SocketComp->bDisabled && SocketComp->SlotPrefix.ToString().Contains(GripIdentifier, ESearchCase::IgnoreCase, ESearchDir::FromStart))
-					{
-						float vecLen = FVector::DistSquared(RelativeWorldLocation, SocketComp->GetRelativeLocation());
-
-						if (SocketComp->bAlwaysInRange)
-						{
-							TargetHandSocket = SocketComp;
-							ClosestSlotDistance = vecLen;
-							bHadSlotInRange = true;
-						}
-						else
-						{
-							float RangeVal = (SocketComp->OverrideDistance > 0.0f ? FMath::Square(SocketComp->OverrideDistance) : MaxRange);
-							if (RangeVal >= vecLen && (ClosestSlotDistance < 0.0f || vecLen < ClosestSlotDistance))
-							{
-								if (SocketComp->bMatchRotation)
-								{
-									RotationallyMatchingHandSockets.Add(SocketComp);
-								}
-								else
-								{
-									TargetHandSocket = SocketComp;
-									ClosestSlotDistance = vecLen;
-									bHadSlotInRange = true;
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// Try and sort through any hand sockets flagged as rotationally matched
-		if (RotationallyMatchingHandSockets.Num() > 0)
-		{
-			FQuat ControllerRot = QueryController->GetPivotTransform().GetRotation();
-			FQuat ClosestQuat = RotationallyMatchingHandSockets[0]->GetComponentTransform().GetRotation();
-
-			TargetHandSocket = RotationallyMatchingHandSockets[0];
-			bHadSlotInRange = true;
-			ClosestSlotDistance = ControllerRot.AngularDistance(ClosestQuat);
-			for (int i= 1; i<RotationallyMatchingHandSockets.Num(); i++)
-			{
-				float CheckDistance = ControllerRot.AngularDistance(RotationallyMatchingHandSockets[i]->GetComponentTransform().GetRotation());
-				if (CheckDistance < ClosestSlotDistance)
-				{
-					TargetHandSocket = RotationallyMatchingHandSockets[i];
-					ClosestSlotDistance = CheckDistance;
-				}
-			}
-		}
-
-
-		if (bHadSlotInRange)
-		{
-			if (TargetHandSocket)
-			{
-				SlotWorldTransform = TargetHandSocket->GetHandSocketTransform(QueryController);
-				SlotName = TargetHandSocket->GetFName();
-				SlotWorldTransform.SetScale3D(FVector(1.0f));
-			}
-			else
-			{
-				SlotWorldTransform = rootComp->GetSocketTransform(SocketNames[foundIndex]);
-				SlotName = SocketNames[foundIndex];
-				SlotWorldTransform.SetScale3D(FVector(1.0f));
-			}
-		}
+		GetGripSlotInRangeByTypeName_Component(SlotType, rootComp, WorldLocation, MaxRange, bHadSlotInRange, SlotWorldTransform, SlotName, QueryController);
 	}
 }
 
-void UVRExpansionFunctionLibrary::GetGripSlotInRangeByTypeName_Component(FName SlotType, UPrimitiveComponent * Component, FVector WorldLocation, float MaxRange, bool & bHadSlotInRange, FTransform & SlotWorldTransform, FName & SlotName, UGripMotionControllerComponent* QueryController)
+void UVRExpansionFunctionLibrary::GetGripSlotInRangeByTypeName_Component(FName SlotType, USceneComponent* Component, FVector WorldLocation, float MaxRange, bool & bHadSlotInRange, FTransform & SlotWorldTransform, FName & SlotName, UGripMotionControllerComponent* QueryController)
 {
 	bHadSlotInRange = false;
 	SlotWorldTransform = FTransform::Identity;
@@ -401,9 +298,16 @@ void UVRExpansionFunctionLibrary::GetGripSlotInRangeByTypeName_Component(FName S
 					float vecLen = FVector::DistSquared(RelativeWorldLocation, SocketComp->GetRelativeLocation());
 					if (SocketComp->bAlwaysInRange)
 					{
-						TargetHandSocket = SocketComp;
-						ClosestSlotDistance = vecLen;
-						bHadSlotInRange = true;
+						if (SocketComp->bMatchRotation)
+						{
+							RotationallyMatchingHandSockets.Add(SocketComp);
+						}
+						else
+						{
+							TargetHandSocket = SocketComp;
+							ClosestSlotDistance = vecLen;
+							bHadSlotInRange = true;
+						}
 					}
 					else
 					{
@@ -431,14 +335,16 @@ void UVRExpansionFunctionLibrary::GetGripSlotInRangeByTypeName_Component(FName S
 	if (RotationallyMatchingHandSockets.Num() > 0)
 	{
 		FQuat ControllerRot = QueryController->GetPivotTransform().GetRotation();
-		FQuat ClosestQuat = RotationallyMatchingHandSockets[0]->GetComponentTransform().GetRotation();
+		FQuat ClosestQuat = RotationallyMatchingHandSockets[0]->GetHandSocketTransform(QueryController).GetRotation();
 
 		TargetHandSocket = RotationallyMatchingHandSockets[0];
 		bHadSlotInRange = true;
 		ClosestSlotDistance = ControllerRot.AngularDistance(ClosestQuat);
 		for (int i = 1; i < RotationallyMatchingHandSockets.Num(); i++)
 		{
-			float CheckDistance = ControllerRot.AngularDistance(RotationallyMatchingHandSockets[i]->GetComponentTransform().GetRotation());
+			float CheckDistance = ControllerRot.AngularDistance(
+				RotationallyMatchingHandSockets[i]->GetHandSocketTransform(QueryController).GetRotation()
+			);
 			if (CheckDistance < ClosestSlotDistance)
 			{
 				TargetHandSocket = RotationallyMatchingHandSockets[i];

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRExpansionFunctionLibrary.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRExpansionFunctionLibrary.h
@@ -183,9 +183,9 @@ public:
 	UFUNCTION(BlueprintPure, Category = "VRGrip", meta = (bIgnoreSelf = "true", DisplayName = "GetGripSlotInRangeByTypeName"))
 	static void GetGripSlotInRangeByTypeName(FName SlotType, AActor * Actor, FVector WorldLocation, float MaxRange, bool & bHadSlotInRange, FTransform & SlotWorldTransform, FName & SlotName, UGripMotionControllerComponent* QueryController = nullptr);
 
-	// Gets if an actors root component contains a grip slot within range
+	// Gets if a component contains a grip slot within range
 	UFUNCTION(BlueprintPure, Category = "VRGrip", meta = (bIgnoreSelf = "true", DisplayName = "GetGripSlotInRangeByTypeName_Component"))
-	static void GetGripSlotInRangeByTypeName_Component(FName SlotType, UPrimitiveComponent * Component, FVector WorldLocation, float MaxRange, bool & bHadSlotInRange, FTransform & SlotWorldTransform, FName & SlotName, UGripMotionControllerComponent* QueryController = nullptr);
+	static void GetGripSlotInRangeByTypeName_Component(FName SlotType, USceneComponent* Component, FVector WorldLocation, float MaxRange, bool & bHadSlotInRange, FTransform & SlotWorldTransform, FName & SlotName, UGripMotionControllerComponent* QueryController = nullptr);
 
 	/* Returns true if the values are equal (A == B) */
 	UFUNCTION(BlueprintPure, meta = (DisplayName = "Equal VR Grip", CompactNodeTitle = "==", Keywords = "== equal"), Category = "VRExpansionFunctions")


### PR DESCRIPTION
The main fix is that it was using GetComponentTransform rather than GetHandSocketTransform, meaning it wasn't using the mirrored hand socket for comparison.

Some other changes which aren't necessary but they're there if you wanted them:
I changed GetGripSlotInRangeByTypeName_Component to use a USceneComponent* as it didn't need to use a UPrimitiveComponent*
This then means that GetGripSlotInRangeByTypeName can call GetGripSlotInRangeByTypeName_Component with the root component which keeps the code a bit cleaner.
If you don't take this change then you'll need to replicate the fix to GetGripSlotInRangeByTypeName.

Additionally bAlwaysInRange didn't work with bMatchRotation, so made it work with it as I assume that's the correct behaviour.

Some changes are just auto CRLF stuff, which I tried to undo but had difficulties with editor/git so left in for now.
It does make it look like it's changing a lot more than it is which is annoying