### PR TITLE
Added VRLocalPlayer Class & VRCameraManager Class (Spawning 0,0,0 & Flicker Fix)

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRCameraManager.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRCameraManager.cpp
@@ -1,0 +1,10 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "VRCameraManager.h"
+
+//cameramanager class with Fade set to black remember to fade back in on begin play of your character class or controller
+AVRCameraManager::AVRCameraManager(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+	SetManualCameraFade(1, FColor(0), false);
+}

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRLocalPlayer.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRLocalPlayer.cpp
@@ -1,0 +1,12 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "VRLocalPlayer.h"
+#include "VRPlayerController.h"
+
+//override fix to flickering caused by networking replication of local controller
+//Set this class to your project settings LocalPlayer class
+UVRLocalPlayer::UVRLocalPlayer(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+	PendingLevelPlayerControllerClass = AVRPlayerController::StaticClass();
+}

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRPlayerController.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRPlayerController.cpp
@@ -4,6 +4,7 @@
 #include "AI/NavigationSystemBase.h"
 #include "VRBaseCharacterMovementComponent.h"
 #include "Engine/Player.h"
+#include "VRCameraManager.h"
 //#include "Runtime/Engine/Private/EnginePrivate.h"
 
 
@@ -11,6 +12,15 @@ AVRPlayerController::AVRPlayerController(const FObjectInitializer& ObjectInitial
 	: Super(ObjectInitializer)
 {
 	bDisableServerUpdateCamera = true;
+	//now constructing VRCameraManager (fix to 0,0,0 and flicker)
+	PlayerCameraManagerClass = AVRCameraManager::StaticClass();
+}
+
+//calls super and fades back in on controller begin play (Fix to 0,0,0 and flicker)
+void AVRPlayerController::BeginPlay()
+{
+	Super::BeginPlay();
+	PlayerCameraManager->StartCameraFade(1, 0, 2.0, FColor(0), false);
 }
 
 void AVRPlayerController::SpawnPlayerCameraManager()

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRCameraManager.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRCameraManager.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Camera/PlayerCameraManager.h"
+#include "VRCameraManager.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class VREXPANSIONPLUGIN_API AVRCameraManager : public APlayerCameraManager
+{
+	GENERATED_UCLASS_BODY()
+	
+};

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRLocalPlayer.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRLocalPlayer.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/LocalPlayer.h"
+#include "VRLocalPlayer.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class VREXPANSIONPLUGIN_API UVRLocalPlayer : public ULocalPlayer
+{
+	GENERATED_UCLASS_BODY()
+	
+};

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRPlayerController.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRPlayerController.h
@@ -26,6 +26,10 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "VRPlayerController")
 		bool bDisableServerUpdateCamera;
 
+	
+	//Add begin play so we can call super and fade in using VRCameraManager (fix to 0,0,0 & Flicker)
+	void BeginPlay();
+
 	/** spawn cameras for servers and owning players */
 	virtual void SpawnPlayerCameraManager() override;
 


### PR DESCRIPTION
Will need to set the cameramanager in your player controller to use the VRCameraManager class (I've done this on constructor for the default value in AVRplayerController & added a begin play after super call for fading back in (Regardless of Blueprint node calls) Tested with current blueprint VRETemplate and no blueprint changes are needed. 

Will need to set the Default LocalPlayer Class to VRLocalPlayer in project settings.

