### PR TITLE
Building for Linux or other case-sensitive platforms fails

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacter.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacter.cpp
@@ -9,7 +9,7 @@
 #include "GripMotionControllerComponent.h"
 #include "VRPathFollowingComponent.h"
 #include "Net/UnrealNetwork.h"
-#include "XRMotioncontrollerBase.h"
+#include "XRMotionControllerBase.h"
 //#include "Runtime/Engine/Private/EnginePrivate.h"
 
 DEFINE_LOG_CATEGORY(LogBaseVRCharacter);


### PR DESCRIPTION
Building for Linux or other case-sensitive platforms fails with the following error:

error : non-portable path to file '"XRMotionControllerBase.h"'; specified path differs in case from file name on disk [-Werror,-Wnonportable-include-path]

There is a typo in #include "XRMotioncontrollerBase.h" line. Strangely, it compiles fine for Windows.