### PR TITLE
OpenXRExpansionPlugin now compiling on Mac

### DIFF
--- a/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/OpenXRExpansionPlugin.Build.cs
+++ b/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/OpenXRExpansionPlugin.Build.cs
@@ -45,11 +45,20 @@ namespace UnrealBuildTool.Rules
                     "SlateCore",
 					//"LiveLink",
 					//"LiveLinkInterface",
-					"OpenXRHMD"
                 }
 				);
-
-            AddEngineThirdPartyPrivateStaticDependencies(Target, "OpenXR");
+                
+            if (Target.Platform != UnrealTargetPlatform.Mac
+            {
+                PrivateDependencyModuleNames.AddRange(
+                    new string[]
+                    {
+                        "OpenXRHMD"
+                    }
+                );
+                PrivateDefinitions.AddRange(new string[] { "OPENXR_SUPPORTED" });
+                AddEngineThirdPartyPrivateStaticDependencies(Target, "OpenXR");
+            }
 
            // if (Target.bBuildEditor == true)
            // {

--- a/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/Private/OpenXRExpansionFunctionLibrary.cpp
+++ b/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/Private/OpenXRExpansionFunctionLibrary.cpp
@@ -22,6 +22,7 @@ UOpenXRExpansionFunctionLibrary::~UOpenXRExpansionFunctionLibrary()
 
 void UOpenXRExpansionFunctionLibrary::GetXRMotionControllerType(FString& TrackingSystemName, EBPOpenXRControllerDeviceType& DeviceType, EBPXRResultSwitch& Result)
 {
+#if defined(OPENXR_SUPPORTED)
 	DeviceType = EBPOpenXRControllerDeviceType::DT_UnknownController;
 	Result = EBPXRResultSwitch::OnFailed;
 
@@ -144,6 +145,7 @@ void UOpenXRExpansionFunctionLibrary::GetXRMotionControllerType(FString& Trackin
 			}
 		}
 	}
+#endif
 
 	TrackingSystemName.Empty();
 	return;

--- a/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/Public/OpenXRExpansionFunctionLibrary.h
+++ b/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/Public/OpenXRExpansionFunctionLibrary.h
@@ -7,8 +7,10 @@
 #include "UObject/Object.h"
 #include "Engine/EngineTypes.h"
 #include "HeadMountedDisplayTypes.h"
+#if defined(OPENXR_SUPPORTED)
 #include "OpenXRCore.h"
 #include "OpenXRHMD.h"
+#endif
 #include "OpenXRExpansionTypes.h"
 #include "HeadMountedDisplayFunctionLibrary.h"
 
@@ -17,6 +19,9 @@
 
 #include "OpenXRExpansionFunctionLibrary.generated.h"
 
+#if !defined(OPENXR_SUPPORTED)
+class FOpenXRHMD;
+#endif
 
 DECLARE_LOG_CATEGORY_EXTERN(OpenXRExpansionFunctionLibraryLog, Log, All);
 
@@ -51,11 +56,13 @@ public:
 
 	static FOpenXRHMD* GetOpenXRHMD()
 	{
+#if defined(OPENXR_SUPPORTED)
 		static FName SystemName(TEXT("OpenXR"));
 		if (GEngine->XRSystem.IsValid() && (GEngine->XRSystem->GetSystemName() == SystemName))
 		{
 			return static_cast<FOpenXRHMD*>(GEngine->XRSystem.Get());
 		}
+#endif
 
 		return nullptr;
 	}


### PR DESCRIPTION
We don't need to actually run OpenXR on a Mac but if we're targeting another platform (Android for the Quest for example) then we need to #ifdef out some OpenXR dependencies to let the plugin successfully compile. The plugin should compile with proper support for any other platform that supports OpenXR (apart from Mac).