### PR TITLE
Added Pico Neo 3 controllers as a recognized OpenXRControllerDeviceType

### DIFF
--- a/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/Private/OpenXRExpansionFunctionLibrary.cpp
+++ b/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/Private/OpenXRExpansionFunctionLibrary.cpp
@@ -129,6 +129,10 @@ void UOpenXRExpansionFunctionLibrary::GetXRMotionControllerType(FString& Trackin
 						{
 							DeviceType = EBPOpenXRControllerDeviceType::DT_OculusGoController;
 						}
+						else if (InteractionName.Find("neo3_controller", ESearchCase::IgnoreCase) != INDEX_NONE)
+						{
+							DeviceType = EBPOpenXRControllerDeviceType::DT_PicoNeo3Controller;
+						}
 						else
 						{
 							UE_LOG(OpenXRExpansionFunctionLibraryLog, Warning, TEXT("UNKNOWN OpenXR Interaction profile detected!!!: %s"), *InteractionName);

--- a/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/Public/OpenXRExpansionFunctionLibrary.h
+++ b/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/Public/OpenXRExpansionFunctionLibrary.h
@@ -39,6 +39,7 @@ enum class EBPOpenXRControllerDeviceType : uint8
 	DT_OculusGoController,
 	DT_MicrosoftMotionController,
 	DT_MicrosoftXboxController,
+	DT_PicoNeo3Controller,
 	DT_UnknownController
 };
 


### PR DESCRIPTION
Added Pico Neo 3 controllers as a recognized OpenXRControllerDeviceType. Pico 4 controllers also register as Pico Neo 3.

Currently, the official Pico OpenXR plugin has the controllers offset at roughly -55 degrees for the y-axis, so a controller profile is necessary for them.