### PR TITLE
Update VRDialComponent.cpp

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Interactibles/VRDialComponent.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Interactibles/VRDialComponent.cpp
@@ -259,7 +259,7 @@ void UVRDialComponent::OnGripRelease_Implementation(UGripMotionControllerCompone
 	{
 		this->SetRelativeRotation((FTransform(UVRInteractibleFunctionLibrary::SetAxisValueRot(DialRotationAxis, FMath::GridSnap(CurRotBackEnd, SnapAngleIncrement), FRotator::ZeroRotator)) * InitialRelativeTransform).Rotator());		
 		CurRotBackEnd = FMath::GridSnap(CurRotBackEnd, SnapAngleIncrement);
-		CurrentDialAngle = FRotator::ClampAxis(FMath::RoundToFloat(CurRotBackEnd));
+		CurrentDialAngle = FMath::RoundToFloat(CurRotBackEnd);
 		
 		if (!FMath::IsNearlyEqual(LastSnapAngle, CurrentDialAngle))
 		{


### PR DESCRIPTION
Changed CurrentDialAngle to equal the rounded version of CurRotBackEnd to prevent CurrentDialAngle from returning an incorrect value when bUseRollover was true.