### PR TITLE
Fix Unreachable Code compile warnings

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Misc/VRRenderTargetManager.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Misc/VRRenderTargetManager.cpp
@@ -1469,6 +1469,7 @@ void RLE_Funcs::RLEWriteRunFlag(uint32 count, uint8** loc, TArray<DataType>& Dat
 	Data.Empty(256);
 }
 
+PRAGMA_DISABLE_UNREACHABLE_CODE_WARNINGS
 template <typename DataType>
 bool RLE_Funcs::RLEEncodeBuffer(DataType* BufferToEncode, uint32 EncodeLength, TArray<uint8>* EncodedLine)
 {
@@ -1646,6 +1647,7 @@ bool RLE_Funcs::RLEEncodeBuffer(DataType* BufferToEncode, uint32 EncodeLength, T
 	else
 		return true;
 }
+PRAGMA_RESTORE_UNREACHABLE_CODE_WARNINGS
 
 template<int32 ScaleFactor, int32 MaxBitsPerComponent>
 bool WritePackedVector2D(FVector2D Value, FArchive& Ar)	// Note Value is intended to not be a reference since we are scaling it before serializing!

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRGlobalSettings.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRGlobalSettings.cpp
@@ -108,9 +108,6 @@ FTransform UVRGlobalSettings::AdjustTransformByGivenControllerProfile(UPARAM(ref
 {
 	// Use currently loaded transform
 	return SocketTransform * (((bIsRightHand && ControllerProfile.bUseSeperateHandOffsetTransforms) ? ControllerProfile.SocketOffsetTransformRightHand : ControllerProfile.SocketOffsetTransform));
-
-	// Couldn't find it, return base transform
-	return SocketTransform;
 }
 
 TArray<FBPVRControllerProfile> UVRGlobalSettings::GetControllerProfiles()


### PR DESCRIPTION
Just cleaned up some unreachable code that was causing my builds to fail.

Deleted code in the AdjustTransformByGivenControllerProfile, but decided to just use PRAGMA_DISABLE_UNREACHABLE_CODE_WARNINGS around RLE_Funcs::RLEEncodeBuffer, since it looks like you want to keep that code as reference.