### PR TITLE
Temporary fix for wrong velocity on non simulation grips

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/GripMotionControllerComponent.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/GripMotionControllerComponent.h
@@ -307,6 +307,14 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "GripMotionController")
 		FVRGripControllerOnGripOutOfRange OnGripOutOfRange;
 
+protected:
+
+	// Fixed velocity sampling for bug in 5.4
+	FTransform FixGrippedLastTransform;
+	FVector FixGrippedVelocity;
+	FVector FixGrippedAngularVelocity;
+
+
 private:
 
 	GENERATED_BODY()


### PR DESCRIPTION
In 5.4 the incorrect velocity gets returned.
Not sure if my Angular Velocity calculations are correct.