### PR TITLE
Fixed undefined type 'ESkinCacheUsage' when compiling on ue5.3

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Grippables/HandSocketComponent.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Grippables/HandSocketComponent.cpp
@@ -14,6 +14,7 @@
 #include "GripMotionControllerComponent.h"
 //#include "VRGripInterface.h"
 //#include "VRBPDatatypes.h"
+#include "Engine/SkinnedAssetCommon.h"
 #include "Net/UnrealNetwork.h"
 #include "Serialization/CustomVersion.h"
 


### PR DESCRIPTION
Missing The header file of the undefined type