### PR TITLE
IOS and Mac Compile Fix

### DIFF
--- a/OpenXRExpansionPlugin/OpenXRExpansionPlugin.uplugin
+++ b/OpenXRExpansionPlugin/OpenXRExpansionPlugin.uplugin
@@ -35,10 +35,7 @@
 		}
 	],
 	"Plugins": [
-		{
-			"Name": "OpenXR",
-			"Enabled": true
-		},
+		
 		{
 			"Name": "XRBase",
 			"Enabled": true

--- a/OpenXRExpansionPlugin/OpenXRExpansionPlugin.uplugin
+++ b/OpenXRExpansionPlugin/OpenXRExpansionPlugin.uplugin
@@ -37,13 +37,13 @@
 	"Plugins": [
 		{
 			"Name": "OpenXR",
-			"Enabled": true,
-			"Optional": true
+			"Enabled": true
 		},
 		{
 			"Name": "XRBase",
 			"Enabled": true
 		}
 	],
-	"IsExperimentalVersion": false
+	"NOTE": "For IOS or Mac remove the OpenXR Dependency here. It will still compile for other platforms but only give a warning."
 }
+

--- a/OpenXRExpansionPlugin/OpenXRExpansionPlugin.uplugin
+++ b/OpenXRExpansionPlugin/OpenXRExpansionPlugin.uplugin
@@ -35,10 +35,15 @@
 		}
 	],
 	"Plugins": [
-		
+		{
+			"Name": "OpenXR",
+			"Enabled": true,
+			"Optional": true
+		},
 		{
 			"Name": "XRBase",
 			"Enabled": true
 		}
-	]
+	],
+	"IsExperimentalVersion": false
 }

--- a/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/OpenXRExpansionPlugin.Build.cs
+++ b/OpenXRExpansionPlugin/Source/OpenXRExpansionPlugin/OpenXRExpansionPlugin.Build.cs
@@ -51,7 +51,7 @@ namespace UnrealBuildTool.Rules
                 }
 				);
                 
-            if (Target.Platform != UnrealTargetPlatform.Mac)
+            if (Target.Platform != UnrealTargetPlatform.Mac && Target.Platform != UnrealTargetPlatform.IOS)
             {
                 PrivateDependencyModuleNames.AddRange(
                     new string[]

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Grippables/GrippablePhysicsReplication.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Grippables/GrippablePhysicsReplication.cpp
@@ -9,7 +9,7 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(GrippablePhysicsReplication)
 
 #include "CoreMinimal.h"
-#include "PhysicsEngine\BodyInstance.h"
+#include "PhysicsEngine/BodyInstance.h"
 #include "Components/PrimitiveComponent.h"
 #include "Components/SkeletalMeshComponent.h"
 #include "UObject/ObjectMacros.h"

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Misc/VRLogComponent.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Misc/VRLogComponent.cpp
@@ -4,8 +4,8 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(VRLogComponent)
 
 #include "Engine/Engine.h"
-#include "GenericPlatform\GenericPlatformInputDeviceMapper.h"
-#include "Engine\GameViewportClient.h"
+#include "GenericPlatform/GenericPlatformInputDeviceMapper.h"
+#include "Engine/GameViewportClient.h"
 #include "GlobalRenderResources.h"
 
 //#include "Engine/Engine.h"

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Misc/VRRenderTargetManager.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Misc/VRRenderTargetManager.cpp
@@ -7,7 +7,7 @@
 #include "GlobalRenderResources.h"
 #include "Components/ActorComponent.h"
 #include "Kismet/GameplayStatics.h"
-#include "GameFramework\Pawn.h"
+#include "GameFramework/Pawn.h"
 #include "GameFramework/PlayerState.h"
 #include "GameFramework/PlayerController.h"
 #include "Engine/TextureRenderTarget2D.h"

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Mover/VRMoverComponent.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/Mover/VRMoverComponent.cpp
@@ -3,9 +3,9 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(VRMoverComponent)
 
 #include "VRBPDatatypes.h"
-#include "DefaultMovementSet\LayeredMoves\BasicLayeredMoves.h"
+#include "DefaultMovementSet/LayeredMoves/BasicLayeredMoves.h"
 #include "Engine/BlueprintGeneratedClass.h"
-#include "Curves\CurveFloat.h" // Delete after tests, only needed for cloning
+#include "Curves/CurveFloat.h" // Delete after tests, only needed for cloning
 #include "ReplicatedVRCameraComponent.h"
 
 DEFINE_LOG_CATEGORY(LogVRMoverComponent);

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBPDatatypes.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBPDatatypes.cpp
@@ -5,7 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "VRGlobalSettings.h"
-#include "Components\PrimitiveComponent.h"
+#include "Components/PrimitiveComponent.h"
 #include "HAL/IConsoleManager.h"
 #include "Chaos/ChaosEngineInterface.h"
 

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacterMovementComponent.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRBaseCharacterMovementComponent.cpp
@@ -19,7 +19,7 @@
 #include "Navigation/PathFollowingComponent.h"
 #include "VRPlayerController.h"
 #include "GameFramework/PhysicsVolume.h"
-#include "Animation\AnimInstance.h"
+#include "Animation/AnimInstance.h"
 
 
 DEFINE_LOG_CATEGORY(LogVRBaseCharacterMovement);

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/Interactibles/VRLeverComponent.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/Interactibles/VRLeverComponent.h
@@ -169,7 +169,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "VRLeverComponent|Momentum Settings", meta = (ClampMin = "0.0", UIMin = "0.0"))
 		float MaxLeverMomentum;
 
-	UPROPERTY(BlueprintReadOnly, Category = "VRLeverComponent")
+	UPROPERTY(BlueprintReadWrite, Category = "VRLeverComponent")
 		bool bIsLerping;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GripSettings")

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/Misc/VRGameViewportClient.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/Misc/VRGameViewportClient.h
@@ -185,7 +185,7 @@ public:
 	}
 };
 
-UVRGameViewportClient::UVRGameViewportClient(const FObjectInitializer& ObjectInitializer)
+inline UVRGameViewportClient::UVRGameViewportClient(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
 	GameInputMethod = EVRGameInputMethod::GameInput_Default;

--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRGestureComponent.h
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Public/VRGestureComponent.h
@@ -6,7 +6,7 @@
 //#include "Engine/Engine.h"
 #include "VRBPDatatypes.h"
 #include "Engine/DataAsset.h"
-#include "Components\SceneComponent.h"
+#include "Components/SceneComponent.h"
 
 //#include "Engine/EngineTypes.h"
 //#include "Engine/EngineBaseTypes.h"


### PR DESCRIPTION
- Fixed wrong slashes
- Excluded OpenXR from IOS in OpenXRExpansionPlugin.Build.cs
- Tried to make OpenXR dependency in .uplugin optional but that doesn't work for compile and instead added a note. That you can remove the OpenXR Dependency so that it will compile for Mac and IOS. For other platforms it will compile too but give a warning.

Unrelated change:
- Made the VR Lever Component Blueprint Read Write so that lerping can be stopped and reenabled in BP code.
- Added inline to UVRGameViewportClient::UVRGameViewportClient