### PR TITLE
fix:avoid permanent root offset in PhysFlying tracking-loss handling

### DIFF
--- a/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRCharacterMovementComponent.cpp
+++ b/VRExpansionPlugin/Source/VRExpansionPlugin/Private/VRCharacterMovementComponent.cpp
@@ -2671,9 +2671,6 @@ void UVRCharacterMovementComponent::PhysFlying(float deltaTime, int32 Iterations
 		return;
 	}
 
-	// Rewind the players position by the new capsule location
-	RewindVRRelativeMovement();
-
 	RestorePreAdditiveRootMotionVelocity();
 	//RestorePreAdditiveVRMotionVelocity();
 
@@ -2699,6 +2696,9 @@ void UVRCharacterMovementComponent::PhysFlying(float deltaTime, int32 Iterations
 		AdditionalVRInputVector = FVector::ZeroVector;
 		LastPreAdditiveVRVelocity = FVector::ZeroVector;
 	}
+	
+	// Rewind the players position by the new capsule location
+	RewindVRRelativeMovement();
 
 	Iterations++;
 	bJustTeleported = false;


### PR DESCRIPTION
Move RewindVRRelativeMovement() to run after AdditionalVRInputVector is clamped/zeroed when TrackingLossThreshold is exceeded, preventing a one-time rewind from becoming a persistent position jump.